### PR TITLE
Make build paths configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 1.5/source/.vs
 1.6/source/obj
 1.6/source/.vs
+1.6/Source/obj/
+Compatibility/CombatExtended/Source/XMT_CE/obj/
+Compatibility/Asari/Source/XMT_ME/obj/
+Directory.Build.local.props
 *.kra~
 *.png~
 About/Preview.kra-autosave.kra

--- a/1.6/Source/XMT.csproj
+++ b/1.6/Source/XMT.csproj
@@ -34,23 +34,23 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\workshop\content\294100\2009463077\Current\Assemblies\0Harmony.dll</HintPath>
+      <HintPath>$(HarmonyAssembliesDir)0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="AlienRace">
-      <HintPath>..\..\..\..\..\..\workshop\content\294100\839005762\1.6\Assemblies\AlienRace.dll</HintPath>
+      <HintPath>$(AlienRaceAssembliesDir)AlienRace.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(RimWorldManagedDir)Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="MVCF">
-      <HintPath>..\..\..\..\..\..\workshop\content\294100\2023507013\1.6\Assemblies\MVCF.dll</HintPath>
+      <HintPath>$(VanillaExpandedFrameworkAssembliesDir)MVCF.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PipeSystem">
-      <HintPath>..\..\..\..\..\..\workshop\content\294100\2023507013\1.6\Assemblies\PipeSystem.dll</HintPath>
+      <HintPath>$(VanillaExpandedFrameworkAssembliesDir)PipeSystem.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -62,20 +62,20 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(RimWorldManagedDir)UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>$(RimWorldManagedDir)UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(RimWorldManagedDir)UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VEF, Version=1.1.7.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\workshop\content\294100\2023507013\1.6\Assemblies\VEF.dll</HintPath>
+      <HintPath>$(VanillaExpandedFrameworkAssembliesDir)VEF.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Compatibility/Asari/Source/XMT_ME/XMT_ME.csproj
+++ b/Compatibility/Asari/Source/XMT_ME/XMT_ME.csproj
@@ -32,15 +32,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\2009463077\Current\Assemblies\0Harmony.dll</HintPath>
+      <HintPath>$(HarmonyAssembliesDir)0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(RimWorldManagedDir)Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="RimEffect">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\3473370247\1.6\Assemblies\RimEffect.dll</HintPath>
+      <HintPath>$(RimEffectAssembliesDir)RimEffect.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -52,11 +52,11 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(RimWorldManagedDir)UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VEF">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\2023507013\1.6\Assemblies\VEF.dll</HintPath>
+      <HintPath>$(VanillaExpandedFrameworkAssembliesDir)VEF.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="XMT">

--- a/Compatibility/CombatExtended/Source/XMT_CE/XMT_CE.csproj
+++ b/Compatibility/CombatExtended/Source/XMT_CE/XMT_CE.csproj
@@ -33,19 +33,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\2009463077\Current\Assemblies\0Harmony.dll</HintPath>
+      <HintPath>$(HarmonyAssembliesDir)0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="AlienRace">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\839005762\1.6\Assemblies\AlienRace.dll</HintPath>
+      <HintPath>$(AlienRaceAssembliesDir)AlienRace.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(RimWorldManagedDir)Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="CombatExtended">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\2890901044\Assemblies\CombatExtended.dll</HintPath>
+      <HintPath>$(CombatExtendedAssembliesDir)CombatExtended.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -57,11 +57,11 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(RimWorldManagedDir)UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VEF">
-      <HintPath>..\..\..\..\..\..\..\..\workshop\content\294100\2023507013\1.6\Assemblies\VEF.dll</HintPath>
+      <HintPath>$(VanillaExpandedFrameworkAssembliesDir)VEF.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <RimWorldInstallDir Condition="'$(RimWorldInstallDir)' == ''">$(MSBuildThisFileDirectory)..\..\RimWorldWin64_Data\</RimWorldInstallDir>
+    <WorkshopContentDir Condition="'$(WorkshopContentDir)' == ''">$(MSBuildThisFileDirectory)..\..\..\..\workshop\content\294100\</WorkshopContentDir>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Directory.Build.local.props" Condition="Exists('$(MSBuildThisFileDirectory)Directory.Build.local.props')" />
+
+  <PropertyGroup>
+    <RimWorldManagedDir Condition="'$(RimWorldManagedDir)' == ''">$(RimWorldInstallDir)Managed\</RimWorldManagedDir>
+    <HarmonyAssembliesDir Condition="'$(HarmonyAssembliesDir)' == ''">$(WorkshopContentDir)2009463077\Current\Assemblies\</HarmonyAssembliesDir>
+    <AlienRaceAssembliesDir Condition="'$(AlienRaceAssembliesDir)' == ''">$(WorkshopContentDir)839005762\1.6\Assemblies\</AlienRaceAssembliesDir>
+    <VanillaExpandedFrameworkAssembliesDir Condition="'$(VanillaExpandedFrameworkAssembliesDir)' == ''">$(WorkshopContentDir)2023507013\1.6\Assemblies\</VanillaExpandedFrameworkAssembliesDir>
+    <CombatExtendedAssembliesDir Condition="'$(CombatExtendedAssembliesDir)' == ''">$(WorkshopContentDir)2890901044\Assemblies\</CombatExtendedAssembliesDir>
+    <RimEffectAssembliesDir Condition="'$(RimEffectAssembliesDir)' == ''">$(WorkshopContentDir)3473370247\1.6\Assemblies\</RimEffectAssembliesDir>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,51 @@
 # Alien | Rimworld
 
+## Building from source
+
+The C# projects target .NET Framework 4.8 and build with MSBuild or Visual Studio.
+
+Build the main mod assembly from the repository root:
+
+```sh
+msbuild 1.6/Source/XMT.csproj /p:Configuration=Debug
+```
+
+On Linux, the .NET SDK can build the project with Mono's .NET Framework reference assemblies:
+
+```sh
+dotnet msbuild 1.6/Source/XMT.csproj /p:Configuration=Debug /p:FrameworkPathOverride=/usr/lib/mono/4.8-api
+```
+
+The debug build writes the mod DLL to:
+
+```text
+1.6/Assemblies/XMT.dll
+```
+
+By default, the projects use the existing relative paths for RimWorld and Steam Workshop dependencies. To use local paths without editing tracked project files, create `Directory.Build.local.props` in the repository root:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <RimWorldInstallDir>/path/to/RimWorld/RimWorld*_Data/</RimWorldInstallDir>
+    <WorkshopContentDir>/path/to/steamapps/workshop/content/294100/</WorkshopContentDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="netstandard">
+      <HintPath>/usr/lib/mono/4.8-api/Facades/netstandard.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="WindowsBase">
+      <HintPath>/usr/lib/mono/4.8-api/WindowsBase.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+</Project>
+```
+
+`Directory.Build.local.props` is ignored by git. You can also override individual assembly folders such as `HarmonyAssembliesDir`, `AlienRaceAssembliesDir`, `VanillaExpandedFrameworkAssembliesDir`, `CombatExtendedAssembliesDir`, or `RimEffectAssembliesDir` if a dependency is installed outside the normal workshop layout.
+
 
 
 ## Getting started


### PR DESCRIPTION
## Summary

Adds a local MSBuild configuration path so contributors can build from source without editing tracked `.csproj` files or creating machine-level symlinks.

The existing relative dependency paths are preserved as defaults, while local paths can be supplied through an ignored `Directory.Build.local.props`.

Addresses #6 

## Changes

- Add `Directory.Build.props` with default RimWorld and Steam Workshop dependency roots.
- Update the main, Combat Extended, and Asari project files to use shared MSBuild properties for dependency `HintPath`s.
- Ignore `Directory.Build.local.props` and generated `obj/` folders.
- Document the build command, local override file, and Linux `dotnet msbuild` setup.

## Verification

Built the main project successfully on Linux using overridden paths with:

```sh
dotnet msbuild 1.6/Source/XMT.csproj /p:Configuration=Debug /p:FrameworkPathOverride=/usr/lib/mono/4.8-api
```